### PR TITLE
Rename Meeting Template to prevent naming clash

### DIFF
--- a/pages/template.md
+++ b/pages/template.md
@@ -53,7 +53,7 @@
 	  areas-for-growth::
 	  other-notes::
 - # Meeting Template
-  template:: One-on-One Template
+  template:: Meeting Template
   template-including-parent:: false
 	- ## Meta
 	  Type:: [/[Meeting]]


### PR DESCRIPTION
Rename to Meeting Template so that it does not clash with One-on-One Template.

Current behavior makes the actual 1:1 Template unreachable when inserting a template into a page. Instead, I get the Meeting Template due to the name clash.

After this change, the 1:1 Template can be inserted correctly.