### PR TITLE
Discriminating based on properties

### DIFF
--- a/pages/PARA%3A Projects.md
+++ b/pages/PARA%3A Projects.md
@@ -18,11 +18,11 @@
 	  query-table:: true
 	  query-properties:: [:page :start :end :tags]
 - ## Completed Projects
-	- {{query (and (property :type [[Project]]) (property :status [[Archive]]) )}}
+	- {{query (and (property :type [[Project]]) (property :status [[Completed]]) )}}
 	  query-table:: true
 	  query-properties:: [:page :start :end :tags]
 - ## Archive
-	- {{query (and [[Project]] [[Archive]] )}}
+	- {{query (and (property :type [[Project]]) (property :status [[Archive]]) )}}
 	  query-table:: true
 	  query-properties:: [:page :start :end :tags]
 - ## Not Categorized

--- a/pages/PARA%3A Projects.md
+++ b/pages/PARA%3A Projects.md
@@ -10,18 +10,22 @@
 		- Etc.
 - ## Active Projects
   title:: PARA: Projects
-	- {{query (and [[Project]] [[Active]] )}}
+	- {{query (and (property :type [[Project]]) (property :status [[Active]]) )}}
 	  query-table:: true
 	  query-properties:: [:page :start :end :tags]
 - ## Upcoming Projects
-	- {{query (and [[Project]] [[Planned]] )}}
+	- {{query (and (property :type [[Project]]) (property :status [[Planned]]) )}}
 	  query-table:: true
 	  query-properties:: [:page :start :end :tags]
 - ## Completed Projects
-	- {{query (and [[Project]] [[Completed]] )}}
+	- {{query (and (property :type [[Project]]) (property :status [[Archive]]) )}}
 	  query-table:: true
 	  query-properties:: [:page :start :end :tags]
 - ## Archive
 	- {{query (and [[Project]] [[Archive]] )}}
+	  query-table:: true
+	  query-properties:: [:page :start :end :tags]
+- ## Not Categorized
+	- {{query (and (property :type [[Project]]) (not (property :status [[Planned]])) (not (property :status [[Active]])) (not (property :status [[Completed]])) (not (property :status [[Archive]])) )}}
 	  query-table:: true
 	  query-properties:: [:page :start :end :tags]


### PR DESCRIPTION
Using properties in the query help narrow down the search results. I have a "Project" property that I use in my "Meetings" blocks, e.g., and all of those blocks were getting picked up in the new "Not Categorized" list. Switching to discriminate on the "type" property fixes this.
 
The "Not Categorized" list is intended to catch projects that I don't properly categorize so I can fix them.